### PR TITLE
Update GitHub Actions workflow paths for Terraform modules

### DIFF
--- a/.github/workflows/infrastructure-release.yml
+++ b/.github/workflows/infrastructure-release.yml
@@ -171,7 +171,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: terraform-plan-${{ github.event.inputs.environment || 'terraform-staging' }}-${{ github.run_id }}
-        path: terraform/modules/tfplan-*
+        path: Infrastructure/modules/tfplan-*
         retention-days: 5
 
     - name: Update Pull Request
@@ -254,7 +254,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./terraform/modules
+        working-directory: ./Infrastructure/modules
 
     steps:
     - name: Checkout
@@ -286,7 +286,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: terraform-plan-${{ github.event.inputs.environment }}-${{ github.run_id }}
-        path: terraform/modules/
+        path: Infrastructure/modules/
 
     - name: Terraform Apply
       id: apply


### PR DESCRIPTION
- Changed paths in the infrastructure-release.yml workflow to reflect the new directory structure, updating references from 'terraform/modules' to 'Infrastructure/modules' for improved organization and consistency.