### PR TITLE
Enhance Terraform apply command in GitHub Actions workflow

### DIFF
--- a/.github/workflows/infrastructure-release.yml
+++ b/.github/workflows/infrastructure-release.yml
@@ -344,7 +344,7 @@ jobs:
       id: apply
       run: |
         echo "🚀 Applying Terraform changes..."
-        terraform apply -no-color "${{ steps.plan.outputs.plan-file }}"
+        terraform apply -no-color -input=false -auto-approve "${{ steps.plan.outputs.plan-file }}"
         
         if [ $? -eq 0 ]; then
           echo "✅ Terraform apply completed successfully"


### PR DESCRIPTION
- Updated the `terraform apply` command in `.github/workflows/infrastructure-release.yml` to include `-input=false` and `-auto-approve` flags, streamlining the deployment process and eliminating manual input requirements during execution.