### PR TITLE
Enhance Terraform policy with additional SSM and IAM permissions

### DIFF
--- a/Infrastructure/terraform/terraform-policy.json
+++ b/Infrastructure/terraform/terraform-policy.json
@@ -93,10 +93,17 @@
         "ssm:DeleteParameter",
         "ssm:DeleteParameters",
         "ssm:DescribeParameters",
-        "ssm:GetParametersByPath"
+        "ssm:GetParametersByPath",
+        "ssm:CreateDocument",
+        "ssm:UpdateDocument",
+        "ssm:DeleteDocument",
+        "ssm:DescribeDocument",
+        "ssm:ListDocuments",
+        "ssm:GetDocument"
       ],
       "Resource": [
-        "arn:aws:ssm:*:*:parameter/docker/swarm/*"
+        "arn:aws:ssm:*:*:parameter/docker/swarm/*",
+        "arn:aws:ssm:*:*:document/${APP_NAME}-*"
       ]
     },
     {
@@ -129,12 +136,19 @@
         "iam:GetRolePolicy",
         "iam:GetInstanceProfile",
         "iam:ListRolePolicies",
-        "iam:ListAttachedRolePolicies"
+        "iam:ListAttachedRolePolicies",
+        "iam:CreateOpenIDConnectProvider",
+        "iam:DeleteOpenIDConnectProvider",
+        "iam:GetOpenIDConnectProvider",
+        "iam:ListOpenIDConnectProviders",
+        "iam:TagOpenIDConnectProvider",
+        "iam:UntagOpenIDConnectProvider"
       ],
       "Resource": [
         "arn:aws:iam::*:role/${APP_NAME}-*",
         "arn:aws:iam::*:policy/${APP_NAME}-*",
-        "arn:aws:iam::*:instance-profile/${APP_NAME}-*"
+        "arn:aws:iam::*:instance-profile/${APP_NAME}-*",
+        "arn:aws:iam::*:oidc-provider/token.actions.githubusercontent.com"
       ]
     },
     {
@@ -177,6 +191,27 @@
         "codedeploy:*"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "CloudWatchLogsPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:DeleteLogGroup",
+        "logs:DeleteLogStream",
+        "logs:PutRetentionPolicy",
+        "logs:DeleteRetentionPolicy",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:log-group:/aws/ec2/${APP_NAME}-*",
+        "arn:aws:logs:*:*:log-group:/aws/ec2/${APP_NAME}-*:log-stream:*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Updated `terraform-policy.json` to include new SSM actions for document management, improving resource handling.
- Added IAM permissions for OpenID Connect provider management, enhancing security and access control.
- Introduced CloudWatch Logs permissions for better logging capabilities, allowing for comprehensive monitoring of EC2 instances.