### PR TITLE
Update GitHub Actions OIDC provider configuration in Terraform module…

### DIFF
--- a/Infrastructure/terraform/modules/github-actions-codedeploy.tf
+++ b/Infrastructure/terraform/modules/github-actions-codedeploy.tf
@@ -92,7 +92,7 @@ resource "aws_iam_role" "github_actions_codedeploy" {
         Action = "sts:AssumeRoleWithWebIdentity"
         Effect = "Allow"
         Principal = {
-          Federated = aws_iam_openid_connect_provider.github_actions_codedeploy.arn
+          Federated = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
         }
         Condition = {
           StringEquals = {


### PR DESCRIPTION
… to use a direct ARN reference for improved clarity and maintainability. This change enhances the trust relationship setup for the GitHub Actions CodeDeploy role.