### PR TITLE
Implement SSH key management

### DIFF
--- a/.github/workflows/infrastructure-release.yml
+++ b/.github/workflows/infrastructure-release.yml
@@ -42,6 +42,7 @@ env:
   TF_VAR_staging_environment: ${{ vars.STAGING_ENVIRONMENT || 'codedeploy-staging' }}
   TF_VAR_production_environment: ${{ vars.PRODUCTION_ENVIRONMENT || 'codedeploy-production' }}
   TF_VAR_environment: ${{ github.event.inputs.environment == 'terraform-production' && 'production' || 'staging' }}
+  TF_VAR_ssh_key_name: ${{ secrets.TF_APP_NAME }}-ssh-key
   
 permissions:
   contents: read
@@ -296,6 +297,59 @@ jobs:
         role-session-name: GitHubActions-Terraform-Apply-${{ github.run_id }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
+    - name: Generate and Store SSH Key
+      if: github.event.inputs.action == 'deploy'
+      run: |
+        echo "🔑 Checking for existing SSH key pair..."
+        
+        KEY_NAME="${{ secrets.TF_APP_NAME }}-ssh-key"
+        PARAMETER_NAME="/ssh/private-key"
+        
+        # Check if EC2 key pair already exists
+        if aws ec2 describe-key-pairs --key-names "$KEY_NAME" --region "${{ env.AWS_DEFAULT_REGION }}" >/dev/null 2>&1; then
+          echo "✅ EC2 key pair '$KEY_NAME' already exists"
+          
+          # Check if private key exists in Parameter Store
+          if aws ssm get-parameter --name "$PARAMETER_NAME" --region "${{ env.AWS_DEFAULT_REGION }}" >/dev/null 2>&1; then
+            echo "✅ Private key already exists in Parameter Store"
+            echo "🔄 Reusing existing SSH key pair"
+          else
+            echo "⚠️  EC2 key pair exists but private key not found in Parameter Store"
+            echo "❌ This is a security issue - private key is missing"
+            echo "🔧 You may need to manually delete the EC2 key pair and redeploy"
+            exit 1
+          fi
+        else
+          echo "🔑 Generating new SSH key pair..."
+          
+          # Generate SSH key pair
+          ssh-keygen -t rsa -b 4096 -f /tmp/ssh-key -N "" -C "terraform-generated"
+          
+          # Store private key in Parameter Store
+          echo "📦 Storing private key in Parameter Store..."
+          aws ssm put-parameter \
+            --name "$PARAMETER_NAME" \
+            --value "$(cat /tmp/ssh-key)" \
+            --type "SecureString" \
+            --description "SSH private key for accessing private instances" \
+            --overwrite
+          
+          # Create key pair in AWS EC2
+          echo "🔐 Creating EC2 key pair..."
+          aws ec2 import-key-pair \
+            --key-name "$KEY_NAME" \
+            --public-key-material "file:///tmp/ssh-key.pub" \
+            --region "${{ env.AWS_DEFAULT_REGION }}"
+          
+          # Clean up local key files
+          rm -f /tmp/ssh-key /tmp/ssh-key.pub
+          
+          echo "✅ New SSH key generated and stored successfully"
+        fi
+        
+        echo "Key pair name: $KEY_NAME"
+        echo "Private key stored in Parameter Store: $PARAMETER_NAME"
+
     - name: Terraform Init
       run: |
         TF_STATE_BUCKET="${{ secrets.TF_STATE_BUCKET }}"
@@ -348,13 +402,17 @@ jobs:
           terraform apply -no-color -input=false -auto-approve "${{ steps.plan.outputs.plan-file }}"
         fi
         
-        if [ $? -eq 0 ]; then
+        APPLY_EXIT_CODE=$?
+        
+        if [ $APPLY_EXIT_CODE -eq 0 ]; then
           echo "✅ Terraform operation completed successfully"
           echo "success=true" >> $GITHUB_OUTPUT
+          echo "exitcode=0" >> $GITHUB_OUTPUT
         else
           echo "❌ Terraform operation failed"
           echo "success=false" >> $GITHUB_OUTPUT
-          exit 1
+          echo "exitcode=$APPLY_EXIT_CODE" >> $GITHUB_OUTPUT
+          exit $APPLY_EXIT_CODE
         fi
 
     - name: Terraform Output

--- a/Infrastructure/terraform/install-docker-manager.sh
+++ b/Infrastructure/terraform/install-docker-manager.sh
@@ -98,8 +98,14 @@ install_docker() {
   log "Docker installed and running ✅"
 }
 
+already_in_swarm() {
+  local state
+  state=$(docker info --format '{{.Swarm.LocalNodeState}}' 2>/dev/null || echo "none")
+  [[ "$state" == "active" || "$state" == "pending" ]]
+}
+
 init_swarm() {
-  if docker info --format '{{.Swarm.LocalNodeState}}' 2>/dev/null | grep -qE 'active|pending'; then
+  if already_in_swarm; then
     log "Swarm already initialised – skipping"
     return
   fi

--- a/Infrastructure/terraform/install-docker-worker.sh
+++ b/Infrastructure/terraform/install-docker-worker.sh
@@ -93,7 +93,9 @@ install_docker() {
 }
 
 already_in_swarm() {
-  docker info --format '{{.Swarm.LocalNodeState}}' 2>/dev/null | grep -qE 'active|pending'
+  local state
+  state=$(docker info --format '{{.Swarm.LocalNodeState}}' 2>/dev/null || echo "none")
+  [[ "$state" == "active" || "$state" == "pending" ]]
 }
 
 get_ssm_param() {

--- a/Infrastructure/terraform/ssh-to-private.sh
+++ b/Infrastructure/terraform/ssh-to-private.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# SSH helper script to connect to private instance
+# Usage: ssh-to-private [private-instance-id]
+
+set -e
+
+# Default private instance ID (you can override by passing as argument)
+PRIVATE_INSTANCE_ID="${PRIVATE_INSTANCE_ID}"
+
+# Use provided instance ID if specified
+if [ $# -eq 1 ]; then
+    PRIVATE_INSTANCE_ID="$1"
+fi
+
+# Check if instance ID is set
+if [ -z "$PRIVATE_INSTANCE_ID" ]; then
+    echo "❌ Error: No private instance ID specified"
+    echo "Usage: ssh-to-private [instance-id]"
+    echo "Or set PRIVATE_INSTANCE_ID environment variable"
+    exit 1
+fi
+
+# Get private IP of the instance
+PRIVATE_IP=$(aws ec2 describe-instances \
+    --instance-ids "$PRIVATE_INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].PrivateIpAddress' \
+    --output text)
+
+if [ "$PRIVATE_IP" = "None" ] || [ -z "$PRIVATE_IP" ]; then
+    echo "❌ Error: Could not get private IP for instance $PRIVATE_INSTANCE_ID"
+    exit 1
+fi
+
+echo "🔑 Retrieving SSH key from Parameter Store..."
+
+# Get SSH key from Parameter Store
+aws ssm get-parameter \
+    --name "/ssh/private-key" \
+    --with-decryption \
+    --query 'Parameter.Value' \
+    --output text > /tmp/private-key.pem
+
+if [ $? -ne 0 ]; then
+    echo "❌ Error: Failed to retrieve SSH key from Parameter Store"
+    echo "Make sure the key is stored at /ssh/private-key"
+    exit 1
+fi
+
+# Set proper permissions
+chmod 400 /tmp/private-key.pem
+
+echo "🔗 Connecting to private instance at $PRIVATE_IP..."
+echo "Instance ID: $PRIVATE_INSTANCE_ID"
+echo ""
+echo "To connect manually: ssh -i /tmp/private-key.pem ec2-user@$PRIVATE_IP"
+echo ""
+
+# Connect to private instance
+ssh -i /tmp/private-key.pem -o StrictHostKeyChecking=no ec2-user@"$PRIVATE_IP"
+
+# Clean up key file
+rm -f /tmp/private-key.pem 

--- a/Infrastructure/terraform/terraform-policy.json
+++ b/Infrastructure/terraform/terraform-policy.json
@@ -105,8 +105,20 @@
       ],
       "Resource": [
         "arn:aws:ssm:*:*:parameter/docker/swarm/*",
+        "arn:aws:ssm:*:*:parameter/ssh/*",
         "arn:aws:ssm:*:*:document/${APP_NAME}-*"
       ]
+    },
+    {
+      "Sid": "EC2KeyPairManagement",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ImportKeyPair",
+        "ec2:DeleteKeyPair",
+        "ec2:DescribeKeyPairs",
+        "ec2:CreateKeyPair"
+      ],
+      "Resource": "*"
     },
     {
       "Sid": "SSMAssociationManagement",


### PR DESCRIPTION
enhance Docker swarm initialization Terraform scripts

- Updated `.github/workflows/infrastructure-release.yml` to generate and store SSH keys for EC2 instances, improving security and access management.
- Added a new SSH helper script `ssh-to-private.sh` to facilitate connections to private instances, enhancing usability.
- Refactored Docker swarm initialization logic in `install-docker-manager.sh` and `install-docker-worker.sh` to improve readability and maintainability.
- Enhanced Terraform policies in `terraform-policy.json` to include permissions for EC2 key pair management and SSM access for SSH keys, ensuring proper access control.