### PR TITLE
Enhance infrastructure release workflow and certificate management setup

### DIFF
--- a/.github/workflows/infrastructure-release.yml
+++ b/.github/workflows/infrastructure-release.yml
@@ -42,6 +42,10 @@ env:
   TF_VAR_staging_environment: ${{ vars.STAGING_ENVIRONMENT || 'codedeploy-staging' }}
   TF_VAR_production_environment: ${{ vars.PRODUCTION_ENVIRONMENT || 'codedeploy-production' }}
   TF_VAR_environment: ${{ github.event.inputs.environment == 'terraform-production' && 'production' || 'staging' }}
+  TF_VAR_domain_name: ${{ secrets.DOMAIN_NAME }}
+  TF_VAR_api_subdomain: ${{ vars.API_SUBDOMAIN || 'api' }}
+  TF_VAR_route53_hosted_zone_id: ${{ secrets.ROUTE53_HOSTED_ZONE_ID }}
+  TF_VAR_bucket_suffix: ${{ secrets.BUCKET_SUFFIX }}
   
 permissions:
   contents: read
@@ -136,6 +140,57 @@ jobs:
         terraform workspace select -or-create "$WORKSPACE"
         
         echo "Current workspace: $(terraform workspace show)"
+
+    - name: Import Existing S3 Buckets
+      if: github.event.inputs.action == 'deploy' && github.event_name == 'workflow_dispatch'
+      run: |
+        echo "🔍 Checking for existing S3 buckets to import..."
+        
+        # Generate bucket hash (same logic as setup script)
+        BUCKET_HASH=$(echo "${{ secrets.AWS_ACCOUNT_ID }}-${{ secrets.GITHUB_REPOSITORY }}" | md5sum | cut -c1-8)
+        
+        # Define bucket names
+        CERTIFICATE_BUCKET="${TF_VAR_app_name}-certificate-store-${TF_VAR_environment}"
+        CODEDEPLOY_BUCKET="codedeploy-${BUCKET_HASH}"
+        
+        echo "Checking buckets:"
+        echo "  Certificate Store: $CERTIFICATE_BUCKET"
+        echo "  CodeDeploy: $CODEDEPLOY_BUCKET"
+        
+        # Function to import bucket if it exists and is not in state
+        import_bucket_if_needed() {
+          local bucket_name=$1
+          local resource_name=$2
+          
+          echo "Checking bucket: $bucket_name"
+          
+          # Check if bucket exists in AWS
+          if aws s3api head-bucket --bucket "$bucket_name" 2>/dev/null; then
+            echo "  ✅ Bucket exists in AWS"
+            
+            # Check if bucket is already in Terraform state
+            if terraform state show "$resource_name" >/dev/null 2>&1; then
+              echo "  ✅ Bucket already in Terraform state"
+            else
+              echo "  📥 Importing bucket into Terraform state..."
+              if terraform import "$resource_name" "$bucket_name"; then
+                echo "  ✅ Successfully imported $bucket_name"
+              else
+                echo "  ⚠️  Failed to import $bucket_name (may already be managed or have dependencies)"
+              fi
+            fi
+          else
+            echo "  ℹ️  Bucket does not exist in AWS (will be created by Terraform)"
+          fi
+        }
+        
+        # Import certificate store bucket
+        import_bucket_if_needed "$CERTIFICATE_BUCKET" "aws_s3_bucket.certificate_store"
+        
+        # Import CodeDeploy bucket
+        import_bucket_if_needed "$CODEDEPLOY_BUCKET" "aws_s3_bucket.codedeploy"
+        
+        echo "✅ S3 bucket import check completed"
 
     - name: Terraform Validate
       id: validate
@@ -326,6 +381,57 @@ jobs:
         WORKSPACE="${{ github.event.inputs.environment }}"
         terraform workspace select -or-create "$WORKSPACE"
         echo "Current workspace: $(terraform workspace show)"
+
+    - name: Import Existing S3 Buckets
+      if: github.event.inputs.action == 'deploy'
+      run: |
+        echo "🔍 Checking for existing S3 buckets to import..."
+        
+        # Generate bucket hash (same logic as setup script)
+        BUCKET_HASH=$(echo "${{ secrets.AWS_ACCOUNT_ID }}-${{ secrets.GITHUB_REPOSITORY }}" | md5sum | cut -c1-8)
+        
+        # Define bucket names
+        CERTIFICATE_BUCKET="${TF_VAR_app_name}-certificate-store-${TF_VAR_environment}"
+        CODEDEPLOY_BUCKET="codedeploy-${BUCKET_HASH}"
+        
+        echo "Checking buckets:"
+        echo "  Certificate Store: $CERTIFICATE_BUCKET"
+        echo "  CodeDeploy: $CODEDEPLOY_BUCKET"
+        
+        # Function to import bucket if it exists and is not in state
+        import_bucket_if_needed() {
+          local bucket_name=$1
+          local resource_name=$2
+          
+          echo "Checking bucket: $bucket_name"
+          
+          # Check if bucket exists in AWS
+          if aws s3api head-bucket --bucket "$bucket_name" 2>/dev/null; then
+            echo "  ✅ Bucket exists in AWS"
+            
+            # Check if bucket is already in Terraform state
+            if terraform state show "$resource_name" >/dev/null 2>&1; then
+              echo "  ✅ Bucket already in Terraform state"
+            else
+              echo "  📥 Importing bucket into Terraform state..."
+              if terraform import "$resource_name" "$bucket_name"; then
+                echo "  ✅ Successfully imported $bucket_name"
+              else
+                echo "  ⚠️  Failed to import $bucket_name (may already be managed or have dependencies)"
+              fi
+            fi
+          else
+            echo "  ℹ️  Bucket does not exist in AWS (will be created by Terraform)"
+          fi
+        }
+        
+        # Import certificate store bucket
+        import_bucket_if_needed "$CERTIFICATE_BUCKET" "aws_s3_bucket.certificate_store"
+        
+        # Import CodeDeploy bucket
+        import_bucket_if_needed "$CODEDEPLOY_BUCKET" "aws_s3_bucket.codedeploy"
+        
+        echo "✅ S3 bucket import check completed"
 
     - name: Download Plan File
       if: github.event.inputs.action == 'deploy'

--- a/Infrastructure/certbot/certificate-manager-daemon.sh
+++ b/Infrastructure/certbot/certificate-manager-daemon.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# manage_certificate_secrets.sh - Daemon wrapper for certificate management
+# Runs certificate-manager.sh at regular intervals
+
+set -Eeuo pipefail
+shopt -s inherit_errexit
+
+readonly LOG_FILE="/var/log/certificate-secret-manager.log"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly CERT_MANAGER_SCRIPT="$SCRIPT_DIR/certificate-manager.sh"
+
+# Default configuration - check every 24 hours
+readonly CHECK_INTERVAL="${CHECK_INTERVAL:-86400}"  # 24 hours in seconds
+readonly DAEMON_MODE="${DAEMON_MODE:-false}"
+
+timestamp() { date "+%Y-%m-%d %H:%M:%S"; }
+
+log() {
+  printf '[ %s ] %s\n' "$(timestamp)" "$*" | tee -a "$LOG_FILE" >&2
+}
+
+on_error() {
+  local ec=$? line=$1
+  log "ERROR: line $line exited with code $ec"
+  exit "$ec"
+}
+trap 'on_error $LINENO' ERR
+
+# Check if running as daemon
+is_daemon_mode() {
+  [[ "$1" == "--daemon" ]]
+}
+
+# Validate prerequisites
+validate_prerequisites() {
+  log "Validating prerequisites"
+  
+  # Check if certificate-manager.sh exists and is executable
+  if [[ ! -f "$CERT_MANAGER_SCRIPT" ]]; then
+    log "ERROR: certificate-manager.sh not found at $CERT_MANAGER_SCRIPT"
+    exit 1
+  fi
+  
+  if [[ ! -x "$CERT_MANAGER_SCRIPT" ]]; then
+    log "ERROR: certificate-manager.sh is not executable"
+    exit 1
+  fi
+  
+  # Check required binaries
+  for bin in jq aws openssl certbot; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+      log "ERROR: required binary '$bin' not found in PATH"
+      exit 1
+    fi
+  done
+  
+  log "Prerequisites validated successfully"
+}
+
+# Run certificate management
+run_certificate_management() {
+  log "Running certificate management"
+  
+  if "$CERT_MANAGER_SCRIPT"; then
+    log "Certificate management completed successfully"
+    return 0
+  else
+    log "ERROR: Certificate management failed"
+    return 1
+  fi
+}
+
+# Daemon mode - run continuously
+run_daemon() {
+  log "Starting certificate secret manager daemon"
+  log "Check interval: ${CHECK_INTERVAL}s ($(($CHECK_INTERVAL / 3600)) hours)"
+  
+  while true; do
+    log "=== Certificate check cycle started ==="
+    
+    if run_certificate_management; then
+      log "Certificate check completed successfully"
+    else
+      log "Certificate check failed, will retry on next cycle"
+    fi
+    
+    log "Sleeping for ${CHECK_INTERVAL}s until next check"
+    sleep "$CHECK_INTERVAL"
+  done
+}
+
+# Single run mode
+run_once() {
+  log "Running certificate management once"
+  run_certificate_management
+}
+
+# Main function
+main() {
+  log "Certificate secret manager started"
+  
+  # Validate prerequisites
+  validate_prerequisites
+  
+  # Determine run mode
+  if is_daemon_mode "$1"; then
+    run_daemon
+  else
+    run_once
+  fi
+}
+
+# Run main function with all arguments
+main "$@" 

--- a/Infrastructure/certbot/certificate-manager.service
+++ b/Infrastructure/certbot/certificate-manager.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Certificate Manager Daemon
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+User=ec2-user
+Group=ec2-user
+WorkingDirectory=/home/ec2-user
+ExecStartPre=/usr/bin/flock -n /run/%N.lock -c true   # single-instance lock
+ExecStart=/home/ec2-user/certificate-manager-daemon.sh --daemon
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=certificate-manager
+
+# Single-instance guarantee
+LockPersonality=yes
+RuntimeDirectory=certificate-manager
+RuntimeDirectoryMode=0755
+
+# Security settings
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/home/ec2-user/certificates /var/log /run/certificate-manager
+
+[Install]
+WantedBy=multi-user.target 

--- a/Infrastructure/certbot/certificate-manager.sh
+++ b/Infrastructure/certbot/certificate-manager.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# certificate-manager v1.1  —  2025-06-27
+#
+# Automates issuance / renewal of Let's Encrypt certificates and
+# stores them in an S3 bucket for other containers to consume.
+#-------------------------------------------------------------------------------
+# TODO: Remove DRY_RUN feature after testing is complete
+#-------------------------------------------------------------------------------
+
+set -Eeuo pipefail
+
+############################################
+# Globals & configuration
+############################################
+readonly LOG_FILE="/var/log/certificate-manager.log"
+readonly STATUS_FILE="/tmp/certificate-manager.status"
+
+readonly S3_BUCKET="${S3_BUCKET:-certificate-store}"
+readonly CERT_PREFIX="${CERT_PREFIX:-certificates}"
+
+readonly DOMAIN="${DOMAIN:-yourdomain.com}"
+readonly INTERNAL_DOMAIN="${INTERNAL_DOMAIN:-}"          # optional
+readonly EMAIL="${EMAIL:-admin@yourdomain.com}"
+
+# The **role name** attached to this EC2 instance/Task (not the ARN/ID).
+readonly AWS_ROLE_NAME="${AWS_ROLE_NAME:-your-app-private-instance-role}"
+
+readonly WILDCARD="${WILDCARD:-true}"
+readonly RENEWAL_THRESHOLD_DAYS="${RENEWAL_THRESHOLD_DAYS:-10}"
+readonly CERT_OUTPUT_DIR="${CERT_OUTPUT_DIR:-/app/certs}"
+# TODO: Remove DRY_RUN after testing is complete
+readonly DRY_RUN="${DRY_RUN:-false}"
+
+# Certbot Docker image
+readonly CERTBOT_IMAGE="certbot/dns-route53:latest"
+
+# single source-of-truth for certificate filenames
+readonly CERT_FILES=(cert.pem privkey.pem fullchain.pem)
+
+############################################
+# Helper utilities
+############################################
+timestamp() { date "+%Y-%m-%d %H:%M:%S"; }
+
+log() {
+  printf '[ %s ] %s\n' "$(timestamp)" "$*" | tee -a "$LOG_FILE" >&2
+}
+
+status() {
+  local state="$1" msg="$2"
+  printf '%s: %s at %s\n' "$state" "$msg" "$(timestamp)" >"$STATUS_FILE"
+  log "STATUS ➜ $state – $msg"
+}
+
+on_error() {
+  local ec=$? line=$1
+  status "FAILED" "line $line exited with code $ec"
+  exit "$ec"
+}
+trap 'on_error $LINENO' ERR
+trap cleanup_aws_credentials EXIT      # always clear creds on exit
+
+############################################
+# Prerequisite check (fail fast)
+############################################
+for bin in jq aws openssl docker; do
+  command -v "$bin" >/dev/null 2>&1 || {
+    log "ERROR: required binary '$bin' not found in PATH"; exit 1;
+  }
+done
+
+############################################
+# Docker helpers
+############################################
+pull_certbot_image() {
+  log "Pulling certbot Docker image: $CERTBOT_IMAGE"
+  if docker pull "$CERTBOT_IMAGE"; then
+    log "Successfully pulled certbot image"
+  else
+    log "ERROR: Failed to pull certbot image"
+    status "FAILED" "Docker image pull failed"
+    exit 1
+  fi
+}
+
+run_certbot() {
+  local cert_dir="$1"
+  local domain="$2"
+  local wildcard="$3"
+  
+  local docker_args=(
+    run --rm
+    -v "$cert_dir:/etc/letsencrypt"
+    -v "/var/lib/letsencrypt:/var/lib/letsencrypt"
+    -v "/var/log/letsencrypt:/var/log/letsencrypt"
+    -e AWS_ACCESS_KEY_ID
+    -e AWS_SECRET_ACCESS_KEY
+    -e AWS_SESSION_TOKEN
+    -e AWS_DEFAULT_REGION
+    "$CERTBOT_IMAGE"
+  )
+  
+  local certbot_args=(
+    certonly --dns-route53
+    -m "$EMAIL" --agree-tos --non-interactive
+  )
+  
+  if [[ $DRY_RUN == true ]]; then
+    certbot_args+=(--dry-run)
+  fi
+  
+  if [[ $wildcard == true ]]; then
+    certbot_args+=(-d "*.${domain}" -d "${domain}")
+  else
+    certbot_args+=(-d "${domain}")
+  fi
+  
+  log "Running certbot for domain: $domain"
+  docker "${docker_args[@]}" certbot "${certbot_args[@]}"
+}
+
+############################################
+# AWS helpers
+############################################
+fetch_aws_credentials() {
+  log "Fetching AWS credentials using IMDSv2"
+
+  local token
+  token=$(curl -s -X PUT \
+      -H "X-aws-ec2-metadata-token-ttl-seconds: 300" \
+      "http://169.254.169.254/latest/api/token") || true
+
+  [[ -z $token ]] && { log "ERROR: IMDSv2 token unavailable"; status "FAILED" "IMDSv2 token missing"; exit 1; }
+
+  local creds_json
+  creds_json=$(curl -s -H "X-aws-ec2-metadata-token: $token" \
+      "http://169.254.169.254/latest/meta-data/iam/security-credentials/$AWS_ROLE_NAME") || true
+
+  if [[ $(jq -r '.Code' <<<"$creds_json") != "Success" ]]; then
+    log "ERROR: failed to fetch AWS credentials (role: $AWS_ROLE_NAME)"
+    status "FAILED" "AWS credential fetch failed"
+    exit 1
+  fi
+
+  export AWS_ACCESS_KEY_ID=$(jq -r '.AccessKeyId'     <<<"$creds_json")
+  export AWS_SECRET_ACCESS_KEY=$(jq -r '.SecretAccessKey' <<<"$creds_json")
+  export AWS_SESSION_TOKEN=$(jq -r '.Token'           <<<"$creds_json")
+  export AWS_DEFAULT_REGION=$(curl -s -H "X-aws-ec2-metadata-token: $token" \
+      http://169.254.169.254/latest/meta-data/placement/region)
+
+  log "AWS credentials exported to environment (region: $AWS_DEFAULT_REGION)"
+}
+
+cleanup_aws_credentials() {
+  log "Cleaning up AWS credentials from environment"
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_DEFAULT_REGION
+}
+
+############################################
+# S3 Certificate Store
+############################################
+download_certificate_from_s3() {
+  local cert_type="$1"   # external | internal
+  local local_dir="$2"
+
+  log "Downloading $cert_type certificate from S3"
+
+  local s3_path="$CERT_PREFIX/$cert_type"
+
+  for file in "${CERT_FILES[@]}"; do
+    local s3_key="$s3_path/$file"
+    local local_file="$local_dir/${cert_type}-$file"
+    if aws s3 cp --only-show-errors "s3://$S3_BUCKET/$s3_key" "$local_file"; then
+      log "Downloaded $file"
+    else
+      log "Certificate file $file not found in S3"
+      return 1
+    fi
+  done
+  log "$cert_type certificate downloaded successfully"
+}
+
+upload_certificate_to_s3() {
+  local cert_type="$1"   # external | internal
+  local local_dir="$2"
+
+  log "Uploading $cert_type certificate to S3"
+
+  local s3_path="$CERT_PREFIX/$cert_type"
+
+  for file in "${CERT_FILES[@]}"; do
+    local s3_key="$s3_path/$file"
+    local local_file="$local_dir/${cert_type}-$file"   # <— fixed mismatch
+    aws s3 cp --only-show-errors "$local_file" "s3://$S3_BUCKET/$s3_key"
+    log "Uploaded $file"
+  done
+}
+
+############################################
+# Certificate validation
+############################################
+check_certificate_validity() {
+  local cert_file="$1" days_threshold="${2:-$RENEWAL_THRESHOLD_DAYS}"
+
+  log "Checking certificate: $cert_file (threshold $days_threshold d)"
+
+  [[ -f $cert_file ]] || { log "Missing file $cert_file"; return 1; }
+
+  local expiry_date expiry_ts now days_left
+  expiry_date=$(openssl x509 -in "$cert_file" -noout -enddate | cut -d= -f2) || return 1
+  expiry_ts=$(date -d "$expiry_date" +%s 2>/dev/null || date -j -f "%b %d %H:%M:%S %Y %Z" "$expiry_date" +%s)
+  now=$(date +%s)
+  days_left=$(( (expiry_ts - now) / 86400 ))
+
+  log "Expires: $expiry_date  (in $days_left days)"
+
+  (( days_left > days_threshold ))
+}
+
+############################################
+# Certificate output management
+############################################
+prepare_certificates_for_output() {
+  local cert_dir="$1"
+
+  log "Preparing certificates for output → $CERT_OUTPUT_DIR"
+  install -m 700 -d "$CERT_OUTPUT_DIR"
+
+  # external certs
+  cp "$cert_dir"/external-cert.pem     "$CERT_OUTPUT_DIR/cert.pem"
+  cp "$cert_dir"/external-privkey.pem  "$CERT_OUTPUT_DIR/cert.key"
+  cp "$cert_dir"/external-fullchain.pem "$CERT_OUTPUT_DIR/fullchain.pem"
+
+  # .pfx for .NET
+  openssl pkcs12 -export               \
+      -in  "$CERT_OUTPUT_DIR/cert.pem" \
+      -inkey "$CERT_OUTPUT_DIR/cert.key" \
+      -out "$CERT_OUTPUT_DIR/aspnetapp.pfx" \
+      -passout pass:
+
+  # internal (optional)
+  if [[ -n "$INTERNAL_DOMAIN" && -f "$cert_dir/internal-cert.pem" ]]; then
+    cp "$cert_dir"/internal-*.pem "$CERT_OUTPUT_DIR"/
+  fi
+
+  chmod 400 "$CERT_OUTPUT_DIR"/*.{pem,pfx}
+
+  date -u +%Y-%m-%dT%H:%M:%SZ > "$CERT_OUTPUT_DIR/last-updated.txt"
+  log "Certificates prepared successfully"
+}
+
+############################################
+# Certificate renewal
+############################################
+renew_certificates() {
+  local cert_dir="$1"
+  
+  # TODO: Remove dry run logic after testing is complete
+  if [[ $DRY_RUN == true ]]; then
+    log "DRY RUN MODE: Simulating certificate renewal with certbot"
+  else
+    log "Renewing certificates with certbot"
+  fi
+
+  # Ensure certbot directories exist
+  mkdir -p "$cert_dir"/{live,renewal} /var/{lib,log}/letsencrypt
+
+  # Pull the certbot image
+  pull_certbot_image
+
+  # -------- external --------
+  log "Renewing external cert for $DOMAIN"
+  run_certbot "$cert_dir" "$DOMAIN" "$WILDCARD"
+
+  # TODO: Remove dry run conditional after testing is complete
+  # In dry run mode, don't copy certificates since they won't be generated
+  if [[ $DRY_RUN != true ]]; then
+    local external_dir="$cert_dir/live/$DOMAIN"
+    cp "$external_dir"/privkey.pem   "$cert_dir/external-privkey.pem"
+    cp "$external_dir"/cert.pem      "$cert_dir/external-cert.pem"
+    cp "$external_dir"/fullchain.pem "$cert_dir/external-fullchain.pem"
+  fi
+
+  # -------- internal (optional) --------
+  if [[ -n "$INTERNAL_DOMAIN" ]]; then
+    log "Renewing internal cert for $INTERNAL_DOMAIN"
+    run_certbot "$cert_dir" "$INTERNAL_DOMAIN" true
+
+    # TODO: Remove dry run conditional after testing is complete
+    # In dry run mode, don't copy certificates since they won't be generated
+    if [[ $DRY_RUN != true ]]; then
+      local internal_dir="$cert_dir/live/$INTERNAL_DOMAIN"
+      cp "$internal_dir"/privkey.pem   "$cert_dir/internal-privkey.pem"
+      cp "$internal_dir"/cert.pem      "$cert_dir/internal-cert.pem"
+      cp "$internal_dir"/fullchain.pem "$cert_dir/internal-fullchain.pem"
+    fi
+  fi
+
+  # TODO: Remove dry run conditional after testing is complete
+  if [[ $DRY_RUN != true ]]; then
+    chmod 400 "$cert_dir"/*.pem
+    log "Certificates renewed successfully"
+  else
+    log "DRY RUN: Certificate renewal simulation completed successfully"
+  fi
+}
+
+############################################
+# Main logic
+############################################
+main() {
+  if [[ $DRY_RUN == true ]]; then
+    log "Certificate manager started in DRY RUN MODE (threshold: $RENEWAL_THRESHOLD_DAYS d)"
+    status "IN_PROGRESS" "Certificate management started (DRY RUN)"
+  else
+    log "Certificate manager started (threshold: $RENEWAL_THRESHOLD_DAYS d)"
+    status "IN_PROGRESS" "Certificate management started"
+  fi
+
+  # workspace & cleanup
+  local cert_dir
+  cert_dir=$(mktemp -d /tmp/certificates.XXXXXX)
+  trap 'rm -rf "$cert_dir"' EXIT
+
+  fetch_aws_credentials
+
+  # ---- download existing certs ----
+  local have_external=false have_internal=false renewal_needed=false
+
+  if download_certificate_from_s3 external "$cert_dir"; then
+    have_external=true
+  fi
+  if [[ -n $INTERNAL_DOMAIN ]] && download_certificate_from_s3 internal "$cert_dir"; then
+    have_internal=true
+  fi
+
+  # ---- validity checks ----
+  if $have_external && check_certificate_validity "$cert_dir/external-cert.pem"; then
+    log "External cert still valid"
+  else
+    renewal_needed=true
+  fi
+
+  if [[ -n $INTERNAL_DOMAIN ]]; then
+    if $have_internal && check_certificate_validity "$cert_dir/internal-cert.pem"; then
+      log "Internal cert still valid"
+    else
+      renewal_needed=true
+    fi
+  fi
+
+  # ---- renew if necessary ----
+  if $renewal_needed; then
+    if [[ $DRY_RUN == true ]]; then
+      log "DRY RUN: Renewal would be required → simulating certbot invocation"
+    else
+      log "Renewal required → invoking certbot"
+    fi
+    renew_certificates "$cert_dir"
+    
+    # Skip S3 uploads in dry run mode
+    if [[ $DRY_RUN != true ]]; then
+      upload_certificate_to_s3 external "$cert_dir"
+      [[ -n $INTERNAL_DOMAIN ]] && upload_certificate_to_s3 internal "$cert_dir"
+    else
+      log "DRY RUN: Skipping S3 uploads"
+    fi
+  else
+    log "All certificates healthy; skipping renewal"
+  fi
+
+  # Skip certificate preparation in dry run mode
+  if [[ $DRY_RUN != true ]]; then
+    prepare_certificates_for_output "$cert_dir"
+  else
+    log "DRY RUN: Skipping certificate preparation for output"
+  fi
+
+  if [[ $DRY_RUN == true ]]; then
+    log "DRY RUN: Certificate management simulation completed successfully 🎉"
+    status "SUCCESS" "Certificate management simulation completed"
+  else
+    log "Certificate management completed successfully 🎉"
+    status "SUCCESS" "Certificate management completed"
+  fi
+}
+
+main "$@"

--- a/Infrastructure/certbot/certificate-secret-manager.service
+++ b/Infrastructure/certbot/certificate-secret-manager.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Certificate Secret Manager
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+User=ec2-user
+Group=ec2-user
+WorkingDirectory=/home/ec2-user
+ExecStartPre=/usr/bin/flock -n /run/%N.lock -c true   # single-instance lock
+ExecStart=/home/ec2-user/Projects/AuthenticationSample/Infrastructure/certbot/certificate-manager-daemon.sh --daemon
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=certificate-secret-manager
+
+# Single-instance guarantee
+LockPersonality=yes
+RuntimeDirectory=certificate-secret-manager
+RuntimeDirectoryMode=0755
+
+# Security settings
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/home/ec2-user/certificates /var/log /run/certificate-secret-manager
+
+[Install]
+WantedBy=multi-user.target 

--- a/Infrastructure/terraform/modules/certificates.tf
+++ b/Infrastructure/terraform/modules/certificates.tf
@@ -1,0 +1,216 @@
+########################
+# SSL Certificates Management
+########################
+
+########################
+# SSL Certificate Store (S3)
+########################
+
+# S3 bucket for SSL certificate storage
+resource "aws_s3_bucket" "ssl_certificates_bucket" {
+  bucket = "${var.app_name}-ssl-certificates-${var.bucket_suffix}"
+
+  tags = {
+    Name        = "${var.app_name}-ssl-certificates-bucket"
+    Environment = var.environment
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# S3 bucket versioning for SSL certificate history
+resource "aws_s3_bucket_versioning" "ssl_certificates_bucket" {
+  bucket = aws_s3_bucket.ssl_certificates_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# S3 bucket encryption
+resource "aws_s3_bucket_server_side_encryption_configuration" "ssl_certificates_bucket" {
+  bucket = aws_s3_bucket.ssl_certificates_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# S3 bucket public access block
+resource "aws_s3_bucket_public_access_block" "ssl_certificates_bucket" {
+  bucket = aws_s3_bucket.ssl_certificates_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# S3 bucket lifecycle policy
+resource "aws_s3_bucket_lifecycle_configuration" "ssl_certificates_bucket" {
+  bucket = aws_s3_bucket.ssl_certificates_bucket.id
+
+  rule {
+    id     = "ssl_certificate_cleanup"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+# IAM policy for SSL certificate bucket access
+resource "aws_iam_policy" "ssl_certificates_bucket_access_policy" {
+  name        = "${var.app_name}-ssl-certificates-bucket-access"
+  description = "Allow access to SSL certificate storage S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.ssl_certificates_bucket.arn,
+          "${aws_s3_bucket.ssl_certificates_bucket.arn}/*"
+        ]
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.app_name}-ssl-certificates-bucket-access"
+    Environment = var.environment
+  }
+}
+
+# Attach SSL certificate bucket policy to public instance role (moved from private)
+resource "aws_iam_role_policy_attachment" "public_ssl_certificates_bucket_access" {
+  role       = aws_iam_role.public_instance_role.name
+  policy_arn = aws_iam_policy.ssl_certificates_bucket_access_policy.arn
+}
+
+# IAM policy for SSL certificate bucket read-only access (private instances)
+resource "aws_iam_policy" "ssl_certificates_bucket_readonly_policy" {
+  name        = "${var.app_name}-ssl-certificates-bucket-readonly"
+  description = "Allow read-only access to SSL certificate storage S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.ssl_certificates_bucket.arn,
+          "${aws_s3_bucket.ssl_certificates_bucket.arn}/*"
+        ]
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.app_name}-ssl-certificates-bucket-readonly"
+    Environment = var.environment
+  }
+}
+
+# Attach SSL certificate bucket read-only policy to private instance role
+resource "aws_iam_role_policy_attachment" "private_ssl_certificates_bucket_readonly" {
+  role       = aws_iam_role.private_instance_role.name
+  policy_arn = aws_iam_policy.ssl_certificates_bucket_readonly_policy.arn
+}
+
+########################
+# Certbot Route53 DNS Challenge Policy
+########################
+
+# IAM policy for certbot Route53 DNS challenge access
+resource "aws_iam_policy" "certbot_route53_dns_challenge_policy" {
+  name        = "${var.app_name}-certbot-route53-dns-challenge"
+  description = "Allow certbot to perform Route53 DNS challenges for SSL certificate validation"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "certbot-route53-dns-challenge-policy"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "route53:ListHostedZones",
+          "route53:GetChange"
+        ]
+        Resource = [
+          "*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "route53:ChangeResourceRecordSets"
+        ]
+        Resource = [
+          "arn:aws:route53:::hostedzone/${data.aws_route53_zone.existing.zone_id}"
+        ]
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.app_name}-certbot-route53-dns-challenge"
+    Environment = var.environment
+  }
+}
+
+# Attach certbot Route53 DNS challenge policy to public instance role (moved from private)
+resource "aws_iam_role_policy_attachment" "public_certbot_route53_dns_challenge" {
+  role       = aws_iam_role.public_instance_role.name
+  policy_arn = aws_iam_policy.certbot_route53_dns_challenge_policy.arn
+}
+
+########################
+# Outputs
+########################
+
+# SSL certificate bucket outputs
+output "ssl_certificates_bucket_name" {
+  value       = aws_s3_bucket.ssl_certificates_bucket.bucket
+  description = "Name of the S3 bucket for SSL certificate storage"
+}
+
+output "ssl_certificates_bucket_arn" {
+  value       = aws_s3_bucket.ssl_certificates_bucket.arn
+  description = "ARN of the S3 bucket for SSL certificate storage"
+}
+
+output "ssl_certificates_bucket_readonly_policy_arn" {
+  value       = aws_iam_policy.ssl_certificates_bucket_readonly_policy.arn
+  description = "ARN of the SSL certificate bucket read-only policy"
+}
+
+# Certbot outputs
+output "certbot_route53_dns_challenge_policy_arn" {
+  value       = aws_iam_policy.certbot_route53_dns_challenge_policy.arn
+  description = "ARN of the certbot Route53 DNS challenge policy"
+}
+
+output "route53_hosted_zone_id" {
+  value       = data.aws_route53_zone.existing.zone_id
+  description = "Route53 hosted zone ID for certbot DNS challenges"
+} 

--- a/Infrastructure/terraform/modules/cloudwatch-agent-config.json
+++ b/Infrastructure/terraform/modules/cloudwatch-agent-config.json
@@ -18,6 +18,13 @@
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
+            "file_path": "/var/log/certificate-manager-cron.log",
+            "log_group_name": "/aws/ec2/${app_name}-certificate-manager-cron",
+            "log_stream_name": "{instance_id}",
+            "timezone": "UTC",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S"
+          },
+          {
             "file_path": "/tmp/docker-manager-setup.status",
             "log_group_name": "/aws/ec2/${app_name}-docker-manager",
             "log_stream_name": "{instance_id}-status",

--- a/Infrastructure/terraform/modules/codedeploy.tf
+++ b/Infrastructure/terraform/modules/codedeploy.tf
@@ -4,7 +4,7 @@
 resource "aws_codedeploy_app" "microservices" {
   for_each = toset(["authentication"]) # Add more services as needed
 
-  name = "${each.key}-${var.environment}"
+  name = "${var.app_name}-${each.key}-${var.environment}"
 
   compute_platform = "Server"
 
@@ -20,7 +20,7 @@ resource "aws_codedeploy_deployment_group" "microservices" {
   for_each = toset(["authentication"]) # Add more services as needed
 
   app_name              = aws_codedeploy_app.microservices[each.key].name
-  deployment_group_name = "${each.key}-${var.environment}-deployment-group"
+  deployment_group_name = "${var.app_name}-${each.key}-${var.environment}-deployment-group"
   service_role_arn      = aws_iam_role.codedeploy_service_role.arn
 
   # Deployment configuration
@@ -116,8 +116,8 @@ resource "aws_iam_policy" "ec2_codedeploy_policy" {
           "s3:ListBucket"
         ]
         Resource = [
-          "arn:aws:s3:::${var.deployment_bucket}",
-          "arn:aws:s3:::${var.deployment_bucket}/*"
+          aws_s3_bucket.codedeploy.arn,
+          "${aws_s3_bucket.codedeploy.arn}/*"
         ]
       },
       {
@@ -141,6 +141,11 @@ resource "aws_iam_policy" "ec2_codedeploy_policy" {
       }
     ]
   })
+
+  tags = {
+    Name        = "${var.app_name}-ec2-codedeploy-policy"
+    Environment = var.environment
+  }
 }
 
 # Attach policy to EC2 CodeDeploy role
@@ -159,7 +164,7 @@ resource "aws_iam_instance_profile" "ec2_codedeploy_profile" {
 resource "aws_cloudwatch_log_group" "codedeploy_logs" {
   for_each = toset(["authentication"]) # Add more services as needed
 
-  name              = "/aws/codedeploy/${each.key}-${var.environment}"
+  name              = "/aws/codedeploy/${var.app_name}-${each.key}-${var.environment}"
   retention_in_days = 14
 
   tags = {
@@ -167,4 +172,83 @@ resource "aws_cloudwatch_log_group" "codedeploy_logs" {
     Environment = var.environment
     Service     = each.key
   }
+}
+
+########################
+# CodeDeploy S3 Bucket
+########################
+
+# S3 bucket for CodeDeploy deployment artifacts
+resource "aws_s3_bucket" "codedeploy" {
+  bucket = "${var.app_name}-codedeploy-${var.bucket_suffix}"
+
+  tags = {
+    Name        = "${var.app_name}-codedeploy-bucket"
+    Environment = var.environment
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# S3 bucket versioning for deployment history
+resource "aws_s3_bucket_versioning" "codedeploy" {
+  bucket = aws_s3_bucket.codedeploy.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# S3 bucket encryption
+resource "aws_s3_bucket_server_side_encryption_configuration" "codedeploy" {
+  bucket = aws_s3_bucket.codedeploy.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# S3 bucket public access block
+resource "aws_s3_bucket_public_access_block" "codedeploy" {
+  bucket = aws_s3_bucket.codedeploy.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# S3 bucket lifecycle policy for deployment artifacts cleanup
+resource "aws_s3_bucket_lifecycle_configuration" "codedeploy" {
+  bucket = aws_s3_bucket.codedeploy.id
+
+  rule {
+    id     = "deployment_cleanup"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    expiration {
+      days = 90
+    }
+  }
+}
+
+########################
+# Outputs
+########################
+
+output "codedeploy_bucket_name" {
+  value       = aws_s3_bucket.codedeploy.bucket
+  description = "Name of the S3 bucket for CodeDeploy deployment artifacts"
+}
+
+output "codedeploy_bucket_arn" {
+  value       = aws_s3_bucket.codedeploy.arn
+  description = "ARN of the S3 bucket for CodeDeploy deployment artifacts"
 } 

--- a/Infrastructure/terraform/modules/route53.tf
+++ b/Infrastructure/terraform/modules/route53.tf
@@ -1,0 +1,76 @@
+########################
+# Route53 DNS Configuration
+########################
+
+# Data source for existing hosted zone
+data "aws_route53_zone" "existing" {
+  zone_id = var.route53_hosted_zone_id
+}
+
+# Local value to reference the hosted zone
+locals {
+  hosted_zone_id = data.aws_route53_zone.existing.zone_id
+  hosted_zone_name = data.aws_route53_zone.existing.name
+}
+
+# A record for the main domain pointing to the public instance
+resource "aws_route53_record" "main_domain" {
+  zone_id = local.hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+  ttl     = "300"
+
+  records = [aws_instance.public.public_ip]
+}
+
+# A record for the API subdomain pointing to the public instance
+resource "aws_route53_record" "api_subdomain" {
+  zone_id = local.hosted_zone_id
+  name    = "${var.api_subdomain}.${var.domain_name}"
+  type    = "A"
+  ttl     = "300"
+
+  records = [aws_instance.public.public_ip]
+}
+
+# CNAME record for www subdomain (optional)
+resource "aws_route53_record" "www_subdomain" {
+  zone_id = local.hosted_zone_id
+  name    = "www.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = "300"
+
+  records = [var.domain_name]
+}
+
+resource "aws_route53_record" "spf" {
+  zone_id = local.hosted_zone_id
+  name    = var.domain_name
+  type    = "TXT"
+  ttl     = "300"
+
+  records = [
+    "v=spf1 include:_spf.google.com ~all"
+  ]
+}
+
+# Outputs
+output "hosted_zone_id" {
+  description = "Route53 hosted zone ID"
+  value       = local.hosted_zone_id
+}
+
+output "hosted_zone_name" {
+  description = "Route53 hosted zone name"
+  value       = local.hosted_zone_name
+}
+
+output "main_domain_url" {
+  description = "Main domain URL"
+  value       = "https://${var.domain_name}"
+}
+
+output "api_domain_url" {
+  description = "API subdomain URL"
+  value       = "https://${var.api_subdomain}.${var.domain_name}"
+} 

--- a/Infrastructure/terraform/setup-github-actions-oidc-policy.json
+++ b/Infrastructure/terraform/setup-github-actions-oidc-policy.json
@@ -67,6 +67,16 @@
         "arn:aws:s3:::codedeploy-*",
         "arn:aws:s3:::codedeploy-*/*"
       ]
+    },
+    {
+      "Sid": "Route53HostedZonePermissions",
+      "Effect": "Allow",
+      "Action": [
+        "route53:ListHostedZones",
+        "route53:GetHostedZone",
+        "route53:ListHostedZonesByName"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/Infrastructure/terraform/terraform-policy.json
+++ b/Infrastructure/terraform/terraform-policy.json
@@ -92,8 +92,6 @@
         "ssm:GetParameters",
         "ssm:DeleteParameter",
         "ssm:DeleteParameters",
-        "ssm:DescribeParameters",
-        "ssm:GetParametersByPath",
         "ssm:CreateDocument",
         "ssm:UpdateDocument",
         "ssm:DeleteDocument",
@@ -108,6 +106,15 @@
         "arn:aws:ssm:*:*:parameter/ssh/*",
         "arn:aws:ssm:*:*:document/${APP_NAME}-*"
       ]
+    },
+    {
+      "Sid": "SSMParameterDiscovery",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:DescribeParameters",
+        "ssm:GetParametersByPath"
+      ],
+      "Resource": "*"
     },
     {
       "Sid": "EC2KeyPairManagement",
@@ -245,6 +252,28 @@
         "logs:FilterLogEvents",
         "logs:TagResource",
         "logs:ListTagsForResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Route53Permissions",
+      "Effect": "Allow",
+      "Action": [
+        "route53:CreateHostedZone",
+        "route53:DeleteHostedZone",
+        "route53:GetHostedZone",
+        "route53:ListHostedZones",
+        "route53:ListHostedZonesByName",
+        "route53:CreateResourceRecordSet",
+        "route53:DeleteResourceRecordSet",
+        "route53:ChangeResourceRecordSets",
+        "route53:GetChange",
+        "route53:ListResourceRecordSets",
+        "route53:GetResourceRecordSet",
+        "route53:TagResource",
+        "route53:UntagResource",
+        "route53:ListTagsForResource",
+        "route53:ListTagsForResources"
       ],
       "Resource": "*"
     }

--- a/Scripts/deployment/remove-infrastructure-workflow.sh
+++ b/Scripts/deployment/remove-infrastructure-workflow.sh
@@ -32,6 +32,8 @@ get_user_input() {
     echo "  • IAM Policy: terraform-github-actions-oidc-policy"
     echo "  • OIDC Provider: token.actions.githubusercontent.com"
     print_warning "S3 Bucket: Terraform state backend (manual deletion required)"
+    print_warning "S3 Bucket: CodeDeploy deployment bucket (manual deletion required)"
+    print_warning "S3 Bucket: Certificate store bucket (manual deletion required)"
     print_warning "Github Secrets, Variables and Environments: (manual deletion required)"
     
     if ! prompt_confirmation "Are you sure you want to delete these resources?" "y/N"; then
@@ -155,9 +157,10 @@ cleanup_oidc_infrastructure() {
 
 # Function to provide instructions for S3 bucket cleanup
 display_state_bucket_cleanup_instructions() {
-    BUCKET_HASH=$(echo "${AWS_ACCOUNT_ID}-${GITHUB_REPO_FULL}" | md5sum | cut -c1-8)
-    TERRAFORM_BUCKET_NAME="terraform-state-${BUCKET_HASH}"
-    CODEDEPLOY_BUCKET_NAME="codedeploy-${BUCKET_HASH}"
+    BUCKET_SUFFIX=$(echo "${AWS_ACCOUNT_ID}-${GITHUB_REPO_FULL}" | md5sum | cut -c1-8)
+    TERRAFORM_BUCKET_NAME="terraform-state-${BUCKET_SUFFIX}"  
+    CERTIFICATE_BUCKET_NAME="<app-name>-certificate-store-${BUCKET_SUFFIX}"
+    CODE_DEPLOY_BUCKET_NAME="codedeploy-${BUCKET_SUFFIX}"
 
     print_warning "S3 bucket cleanup is not automated for safety reasons."
     
@@ -167,12 +170,17 @@ display_state_bucket_cleanup_instructions() {
     echo -e "${GREEN}aws s3 rm s3://$TERRAFORM_BUCKET_NAME --recursive --profile $AWS_PROFILE${NC}"
     echo -e "${GREEN}aws s3api delete-bucket --bucket $TERRAFORM_BUCKET_NAME --profile $AWS_PROFILE${NC}"
     
-    echo -e "${YELLOW}# Delete CodeDeploy deployment bucket:${NC}"
-    echo -e "${GREEN}aws s3 rm s3://$CODEDEPLOY_BUCKET_NAME --recursive --profile $AWS_PROFILE${NC}"
-    echo -e "${GREEN}aws s3api delete-bucket --bucket $CODEDEPLOY_BUCKET_NAME --profile $AWS_PROFILE${NC}"
+    echo -e "${YELLOW}# Delete Certificate store bucket:${NC}"
+    echo -e "${GREEN}aws s3 rm s3://$CERTIFICATE_BUCKET_NAME --recursive --profile $AWS_PROFILE${NC}"
+    echo -e "${GREEN}aws s3api delete-bucket --bucket $CERTIFICATE_BUCKET_NAME --profile $AWS_PROFILE${NC}"
     
-    print_warning "⚠️  WARNING: This will permanently delete your Terraform state and deployment artifacts!"
+    echo -e "${YELLOW}# Delete CodeDeploy bucket:${NC}"
+    echo -e "${GREEN}aws s3 rm s3://$CODE_DEPLOY_BUCKET_NAME --recursive --profile $AWS_PROFILE${NC}"
+    echo -e "${GREEN}aws s3api delete-bucket --bucket $CODE_DEPLOY_BUCKET_NAME --profile $AWS_PROFILE${NC}"
+    
+    print_warning "⚠️  WARNING: This will permanently delete your Terraform state and certificates!"
     print_info "Make sure you have backed up your state or are certain you want to delete it."
+    print_info "Note: CodeDeploy bucket is managed by Terraform and will be cleaned up with terraform destroy."
 }
 
 # Function to display final summary
@@ -185,12 +193,13 @@ display_final_summary() {
     echo "  ✅ OIDC Provider: token.actions.githubusercontent.com"
     echo "  ℹ️  S3 Buckets: Manual deletion required (see instructions above)"
     echo "     - Terraform state bucket"
-    echo "     - CodeDeploy deployment bucket"
+    echo "     - Certificate store bucket"
+    echo "  ℹ️  CodeDeploy bucket: Managed by Terraform"
     
     print_info "Additional cleanup steps:"
     echo "1. Remove GitHub repository secrets:"
     echo "   AWS_ACCOUNT_ID, TF_STATE_BUCKET, TF_APP_NAME, GITHUB_REPOSITORY,"
-    echo "   ECR_REPOSITORY_PREFIX, DEPLOYMENT_BUCKET"
+    echo "   ECR_REPOSITORY_PREFIX"
     echo "2. Remove GitHub repository variables:"
     echo "   AWS_DEFAULT_REGION"
     echo "3. Remove GitHub environments:"


### PR DESCRIPTION
- Updated `.github/workflows/infrastructure-release.yml` to include environment variables for domain name, API subdomain, Route53 hosted zone ID, and bucket suffix.
- Added a new script `certificate-manager-daemon.sh` for managing SSL certificate issuance and renewal, running at regular intervals.
- Created `certificate-manager.service` for systemd integration of the certificate manager daemon.
- Implemented `certificate-manager.sh` for automating Let's Encrypt certificate management and S3 storage.
- Introduced S3 bucket management for SSL certificates and CodeDeploy artifacts in Terraform modules, ensuring proper lifecycle and access policies.
- Enhanced logging and error handling in the certificate management scripts for better visibility and reliability.
- Updated deployment scripts to include instructions for managing new S3 buckets and Route53 configurations.