### PR TITLE
Enhance logging and error handling in certificate renewal script and …

### DIFF
--- a/Infrastructure/terraform/modules/certificates.tf
+++ b/Infrastructure/terraform/modules/certificates.tf
@@ -25,7 +25,7 @@ resource "aws_iam_policy" "secrets_manager_access_policy" {
           "secretsmanager:GetSecretValue"
         ]
         Resource = [
-          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:${var.app_name}-secrets"
+          "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:${var.app_name}-secrets*"
         ]
       }
     ]


### PR DESCRIPTION
…update IAM policy ARN

- Updated `trigger-certificate-renewal.sh` to log errors from AWS Secrets Manager fetch attempts, improving visibility into failures.
- Modified the IAM policy ARN in `certificates.tf` to include a wildcard for better resource access management, ensuring all relevant secrets are accessible.