### PR TITLE
Update logging configuration for certificate manager and renewal scripts

### DIFF
--- a/Infrastructure/certbot/certificate-manager.service
+++ b/Infrastructure/certbot/certificate-manager.service
@@ -17,6 +17,9 @@ WorkingDirectory=%S
 RuntimeDirectory=certificate-manager
 RuntimeDirectoryMode=0755
 
+# Set the log file path to match the certificate-manager directory
+Environment=LOG_FILE=/var/log/certificate-manager/certificate-manager.log
+
 ExecStart=/usr/bin/flock -n %t/certificate-manager/instance.lock /usr/local/bin/certificate-manager.sh --daemon
 
 Restart=always

--- a/Infrastructure/certbot/certificate-manager.sh
+++ b/Infrastructure/certbot/certificate-manager.sh
@@ -3,7 +3,7 @@
 # certificate-manager.sh
 #
 # Fires `trigger-certificate-renewal.sh` either once or at a fixed interval
-# (daemon mode).  Logs go to STDERR *and* `/var/log/certificate-secret-manager.log`.
+# (daemon mode).  Logs go to STDERR *and* the configured log file (default: /var/log/certificate-manager/certificate-manager.log).
 #
 # ---------------------------------------------------------------------------
 # Usage:
@@ -20,7 +20,7 @@
 set -Eeuo pipefail
 
 # ── Defaults ────────────────────────────────────────────────────────────────
-readonly LOG_FILE="${LOG_FILE:-/var/log/certificate-secret-manager.log}"
+readonly LOG_FILE="${LOG_FILE:-/var/log/certificate-manager/certificate-manager.log}"
 readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly TRIGGER_SCRIPT="${TRIGGER_SCRIPT:-${SCRIPT_DIR}/trigger-certificate-renewal.sh}"
 readonly CHECK_INTERVAL="${CHECK_INTERVAL:-86400}"   # 24 h

--- a/Infrastructure/certbot/renew-certificate.sh
+++ b/Infrastructure/certbot/renew-certificate.sh
@@ -11,9 +11,8 @@ set -Eeuo pipefail
 ############################################
 # Globals & configuration
 ############################################
-readonly LOG_DIR="${LOG_DIR:-/var/log}"
-readonly LOG_FILE="${LOG_FILE:-certificate-renewal.log}"
-readonly LOG_FILE_PATH="${LOG_DIR}/${LOG_FILE}"
+readonly LOG_DIR="${LOG_DIR:-/var/log/certificate-manager}"
+readonly LOG_FILE="${LOG_FILE:-/var/log/certificate-manager/certificate-renewal.log}"
 readonly STATUS_FILE="/tmp/certificate-manager.status"
 
 readonly S3_BUCKET="${S3_BUCKET:-certificate-store}"
@@ -42,7 +41,7 @@ readonly CERT_FILES=(cert.pem privkey.pem fullchain.pem)
 timestamp() { date "+%Y-%m-%d %H:%M:%S"; }
 
 log() {
-  printf '[ %s ] %s\n' "$(timestamp)" "$*" | tee -a "$LOG_FILE_PATH" >&2
+  printf '[ %s ] %s\n' "$(timestamp)" "$*" | tee -a "$LOG_FILE" >&2
 }
 
 status() {

--- a/Infrastructure/certbot/trigger-certificate-renewal.sh
+++ b/Infrastructure/certbot/trigger-certificate-renewal.sh
@@ -25,7 +25,7 @@
 #   WORKER_CONSTRAINT          Node label to pin the one-shot task
 #
 #   LOG_DIR                    Directory for log files (default: /var/log)
-#   LOG_FILE                   Log file name (default: certificate-renewal.log)
+#   LOG_FILE                   Log file name (default: /var/log/certificate-manager/certificate-renewal.log)
 #
 # ---------------------------------------------------------------------------
 # Requires: docker, aws-cli
@@ -36,8 +36,8 @@ shopt -s inherit_errexit
 
 # ── Logging configuration ────────────────────────────────────────────────────
 # Log directory for CloudWatch integration
-readonly LOG_DIR="${LOG_DIR:-/var/log}"
-readonly LOG_FILE="${LOG_FILE:-certificate-renewal.log}"
+readonly LOG_DIR="${LOG_DIR:-/var/log/certificate-manager}"
+readonly LOG_FILE="${LOG_FILE:-/var/log/certificate-manager/certificate-renewal.log}"
 
 # ── Logging helpers ──────────────────────────────────────────────────────────
 timestamp()  { date '+%Y-%m-%d %H:%M:%S'; }

--- a/Infrastructure/terraform/modules/cloudwatch-agent-config.json
+++ b/Infrastructure/terraform/modules/cloudwatch-agent-config.json
@@ -18,14 +18,14 @@
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
-            "file_path": "/var/log/certificate-secret-manager.log",
-            "log_group_name": "/aws/ec2/${app_name}-certificate-secret-manager",
+            "file_path": "/var/log/certificate-manager/certificate-manager.log",
+            "log_group_name": "/aws/ec2/${app_name}-certificate-manager",
             "log_stream_name": "{instance_id}",
             "timezone": "UTC",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
-            "file_path": "/var/log/certificate-renewal.log",
+            "file_path": "/var/log/certificate-manager/certificate-renewal.log",
             "log_group_name": "/aws/ec2/${app_name}-certificate-renewal",
             "log_stream_name": "{instance_id}",
             "timezone": "UTC",

--- a/Infrastructure/terraform/modules/scripts.tf
+++ b/Infrastructure/terraform/modules/scripts.tf
@@ -69,11 +69,18 @@ resource "aws_ssm_document" "certificate_manager_setup" {
           # The other directories required by the service need to be created manually.
           "mkdir -p /var/lib/certificate-manager",
           "mkdir -p /run/certificate-manager",
-          "mkdir -p /var/log/certificate-manager",
           # Set proper ownership for systemd directories
           "chown ec2-user:ec2-user /var/lib/certificate-manager",
           "chown ec2-user:ec2-user /run/certificate-manager",
-          "chown ec2-user:ec2-user /var/log/certificate-manager",
+          # Ensure the log file directory exists and has proper permissions
+          "mkdir -p /var/log/certificate-manager",
+          "touch /var/log/certificate-manager/certificate-manager.log",
+          "chown ec2-user:ec2-user /var/log/certificate-manager/certificate-manager.log",
+          "chmod 644 /var/log/certificate-manager/certificate-manager.log",
+          # Create certificate renewal log file with proper permissions
+          "touch /var/log/certificate-manager/certificate-renewal.log",
+          "chown ec2-user:ec2-user /var/log/certificate-manager/certificate-renewal.log",
+          "chmod 644 /var/log/certificate-manager/certificate-renewal.log",
           # Reload systemd and enable the service
           "systemctl daemon-reload",
           "systemctl enable certificate-manager.service",


### PR DESCRIPTION
- Set the log file path in `certificate-manager.service` to align with the new directory structure.
- Updated `certificate-manager.sh` and `trigger-certificate-renewal.sh` to reflect the new default log file paths.
- Enhanced `renew-certificate.sh` to ensure consistent logging across scripts.
- Modified Terraform scripts to create necessary log files with appropriate permissions, improving logging management.