### PR TITLE
Update logging configuration and create new log files for certificate…

### DIFF
--- a/Infrastructure/certbot/trigger-certificate-renewal.sh
+++ b/Infrastructure/certbot/trigger-certificate-renewal.sh
@@ -37,7 +37,7 @@ shopt -s inherit_errexit
 # ── Logging configuration ────────────────────────────────────────────────────
 # Log directory for CloudWatch integration
 readonly LOG_DIR="${LOG_DIR:-/var/log/certificate-manager}"
-readonly LOG_FILE="${LOG_FILE:-/var/log/certificate-manager/certificate-renewal.log}"
+readonly LOG_FILE="${LOG_FILE:-/var/log/certificate-manager/trigger-renewal.log}"
 
 # ── Logging helpers ──────────────────────────────────────────────────────────
 timestamp()  { date '+%Y-%m-%d %H:%M:%S'; }

--- a/Infrastructure/terraform/modules/cloudwatch-agent-config.json
+++ b/Infrastructure/terraform/modules/cloudwatch-agent-config.json
@@ -20,14 +20,21 @@
           {
             "file_path": "/var/log/certificate-manager/certificate-manager.log",
             "log_group_name": "/aws/ec2/${app_name}-certificate-manager",
-            "log_stream_name": "{instance_id}",
+            "log_stream_name": "{instance_id}-manager",
             "timezone": "UTC",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "/var/log/certificate-manager/certificate-renewal.log",
-            "log_group_name": "/aws/ec2/${app_name}-certificate-renewal",
-            "log_stream_name": "{instance_id}",
+            "log_group_name": "/aws/ec2/${app_name}-certificate-manager",
+            "log_stream_name": "{instance_id}-renewal",
+            "timezone": "UTC",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/certificate-manager/trigger-renewal.log",
+            "log_group_name": "/aws/ec2/${app_name}-certificate-manager",
+            "log_stream_name": "{instance_id}-trigger",
             "timezone": "UTC",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },

--- a/Infrastructure/terraform/modules/scripts.tf
+++ b/Infrastructure/terraform/modules/scripts.tf
@@ -77,6 +77,10 @@ resource "aws_ssm_document" "certificate_manager_setup" {
           "touch /var/log/certificate-manager/certificate-manager.log",
           "chown ec2-user:ec2-user /var/log/certificate-manager/certificate-manager.log",
           "chmod 644 /var/log/certificate-manager/certificate-manager.log",
+          # Create trigger renewal log file with proper permissions
+          "touch /var/log/certificate-manager/trigger-renewal.log",
+          "chown ec2-user:ec2-user /var/log/certificate-manager/trigger-renewal.log",
+          "chmod 644 /var/log/certificate-manager/trigger-renewal.log",
           # Create certificate renewal log file with proper permissions
           "touch /var/log/certificate-manager/certificate-renewal.log",
           "chown ec2-user:ec2-user /var/log/certificate-manager/certificate-renewal.log",


### PR DESCRIPTION
… renewal process

- Changed the log file name in `trigger-certificate-renewal.sh` to `trigger-renewal.log` for better clarity.
- Updated `cloudwatch-agent-config.json` to reflect the new log file paths and added a new log stream for the trigger renewal process.
- Modified `scripts.tf` to create the `trigger-renewal.log` file with appropriate permissions, ensuring proper logging setup for the certificate renewal process.