### PR TITLE
Update certbot scripts for enhanced logging and error handling

### DIFF
--- a/Infrastructure/certbot/Dockerfile
+++ b/Infrastructure/certbot/Dockerfile
@@ -21,4 +21,4 @@ RUN chmod +x renew-certificate.sh && \
     mkdir -p /var/log && \
     chmod 755 /var/log
 
-ENTRYPOINT ["/app/renew-certificate.sh"]
+ENTRYPOINT ["/app/renew-certificate.sh", "--dry-run"]

--- a/Infrastructure/terraform/modules/certificates.tf
+++ b/Infrastructure/terraform/modules/certificates.tf
@@ -59,6 +59,12 @@ resource "aws_iam_role_policy_attachment" "private_secrets_manager_access" {
   policy_arn = aws_iam_policy.secrets_manager_access_policy.arn
 }
 
+# Attach Secrets Manager access policy to public instance role
+resource "aws_iam_role_policy_attachment" "public_secrets_manager_access" {
+  role       = aws_iam_role.public_instance_role.name
+  policy_arn = aws_iam_policy.secrets_manager_access_policy.arn
+}
+
 ########################
 # SSL Certificate Store (S3)
 ########################

--- a/Infrastructure/terraform/modules/scripts.tf
+++ b/Infrastructure/terraform/modules/scripts.tf
@@ -119,11 +119,6 @@ resource "aws_ssm_document" "ebs_volume_setup" {
           "mkdir -p /var/log/certificate-manager",
           "chown ec2-user:ec2-user /var/log/certificate-manager",
           "chmod 755 /var/log/certificate-manager",
-          # Create log files with proper permissions
-          "touch /var/log/certificate-manager/certificate-manager.log",
-          "touch /var/log/certificate-manager/ebs-volume-setup.log",
-          "chown ec2-user:ec2-user /var/log/certificate-manager/*.log",
-          "chmod 644 /var/log/certificate-manager/*.log",
           # Create certbot directories (required by renew-certificate.sh)
           "mkdir -p /var/lib/letsencrypt",
           "mkdir -p /var/log/letsencrypt",


### PR DESCRIPTION
- Modified `renew-certificate.sh` to include detailed logging for the certificate renewal process, improving visibility into execution flow and status.
- Updated the entry point in the Dockerfile to run the renewal script in dry-run mode by default, facilitating testing without making actual changes.
- Enhanced error handling in `trigger-certificate-renewal.sh` to capture and log detailed output from AWS commands, aiding in troubleshooting.
- Added a new IAM policy attachment in Terraform to grant Secrets Manager access to the public instance role, ensuring proper permissions for secret management.