### PR TITLE
Enhance certificate renewal script with format string for secret retr…

### DIFF
--- a/Infrastructure/certbot/trigger-certificate-renewal.sh
+++ b/Infrastructure/certbot/trigger-certificate-renewal.sh
@@ -408,9 +408,11 @@ for domain in "${renew_domains[@]}"; do
         log "finding existing certificate secrets for service $service…"
 
         # Collect any cert‑related secrets already attached
+        # Build the format string to avoid Terraform interpolation conflicts  
+        format_string='{{range .Spec.TaskTemplate.ContainerSpec.Secrets}}{{.SecretName}} {{.File.Name}}{{"\\n"}}{{'"end"'}}'
         mapfile -t cert_secrets < <(
             docker service inspect "$service" \
-                --format '{{range .Spec.TaskTemplate.ContainerSpec.Secrets}}{{.SecretName}} {{.File.Name}}{{"\n"}}{{end}}' |
+                --format "$format_string" |
             awk '$2 ~ /^(cert\.pem|privkey\.pem|fullchain\.pem|cert\.pfx)$/ {print $1}'
         )
 


### PR DESCRIPTION
…ieval

- Introduced a format string in `trigger-certificate-renewal.sh` to avoid Terraform interpolation conflicts when collecting existing certificate secrets for services.
- Improved the clarity of the script by ensuring consistent formatting during the inspection of Docker services, enhancing the overall robustness of the certificate renewal process.