### PR TITLE
Update Terraform policy and instance type configuration

### DIFF
--- a/infrastructure/terraform/modules-single-az/compute.tf
+++ b/infrastructure/terraform/modules-single-az/compute.tf
@@ -13,7 +13,7 @@
 variable "instance_type_managers" {
   description = "EC2 instance type for Swarm managers"
   type        = string
-  default     = "t4g.small"
+  default     = "t4g.micro"
 }
 
 variable "instance_types_workers" {

--- a/infrastructure/terraform/terraform-policy.json
+++ b/infrastructure/terraform/terraform-policy.json
@@ -61,7 +61,7 @@
         "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${PROJECT_NAME}-*"
       ],
       "Condition": {
-        "StringEquals": {
+        "StringEqualsIfExists": {
           "iam:PassedToService": [
             "ec2.amazonaws.com",
             "codedeploy.amazonaws.com",


### PR DESCRIPTION
- Changed "StringEquals" to "StringEqualsIfExists" in the IAM policy for improved flexibility in service permissions.
- Updated the default EC2 instance type for managers from "t4g.small" to "t4g.micro" to optimize resource allocation.